### PR TITLE
Optimize computation algorithm

### DIFF
--- a/scripts/math/fractal_calculation.ts
+++ b/scripts/math/fractal_calculation.ts
@@ -7,63 +7,162 @@ type PlotScale = {
     y_display_range: number
 }
 
-class Complex32 {
-    re: number;
-    im: number;
-    constructor(re: number, im: number) {
-        this.re = re;
-        this.im = im;
-    }
-
-    clone() {
-        return new Complex32(this.re, this.im);
-    }
-
-    add(other: Complex32) {
-        this.re += other.re;
-        this.im += other.im;
-    }
-
-    subtract(other: Complex32) {
-        this.re -= other.re;
-        this.im -= other.im;
-    }
-
-    invert() {
-        const square_sum = this.normSqr();
-        this.re /= square_sum;
-        this.im /= -square_sum;
-    }
-
-    normSqr(): number {
-        return this.re * this.re + this.im * this.im;
-    }
-
-    distance(): number {
-        return Math.sqrt(this.re * this.re + this.im * this.im);
-    }
+function complexAbs(real: number, imag: number): number {
+    // This is more numerically stable than `sqrt(x^2 + y^2)`.
+    let ratio = real / imag;
+    return real * Math.sqrt(1 + ratio * ratio);
 }
 
-function newtonMethodApprox(roots: Complex32[], z: Complex32): {
-    idx: number;
-    z: Complex32;
-} {
-    let sum = new Complex32(0, 0);
-    let i = 0;
-    for (const root of roots) {
-        let diff = z.clone();
-        diff.subtract(root);
-        if (Math.abs(diff.re) < 0.001 && Math.abs(diff.im) < 0.001) {
-            return { idx: i, z };
+function getRootId(roots: Float32Array, iterationsCount: number, xp: number, yp: number): number {
+    /*
+    This is the following pseudocode loop where `Im` is the imaginary unit and `real(x)` and
+    `imag(x)` get the real and imaginary parts of `x` respectively:
+
+    ```js
+    let z = xp + yp*Im;
+
+    // Perform a Newton's method approximation using `iterationsCount` rounds to find the
+    // nearest root. If it gets close enough to a root, return it.
+    for (let i = 0; i < iterationsCount; i++) {
+        let sum = 0 + 0*Im;
+        for (let i = 0; i < roots.length; i += 2) {
+            let rootReal = roots[i + 0];
+            let rootImag = roots[i + 1];
+            let root = rootReal + rootImag*Im;
+            let diff = z - root;
+            if (real(diff) < 0.001 && imag(diff) < 0.001) {
+                return i;
+            }
+            sum += 1 / diff;
         }
-        diff.invert();
-        sum.add(diff);
-        i++;
+        z -= 1 / sum;
     }
-    sum.invert();
-    let result = z.clone();
-    result.subtract(sum);
-    return { idx: -1, z: result };
+
+    // Failing a close-enough match, find and return the root with the nearest distance.
+    let minDistance = Infinity;
+    let closestRootId = 0;
+
+    for (let i = 0; i < roots.length; i += 2) {
+        let rootReal = roots[i + 0];
+        let rootImag = roots[i + 1];
+        let dst = abs(z - root);
+        if (dst < minDistance) {
+            minDistance = dst;
+            closestRootId = i;
+        }
+    }
+    return closestRootId;
+    ```
+
+    First, I split it apart into using real and imaginary scalars directly:
+
+    ```js
+    let realZ = xp;
+    let imagZ = yp;
+
+    // Perform a Newton's method approximation using `iterationsCount` rounds to find the
+    // nearest root. If it gets close enough to a root, return it.
+    for (let i = 0; i < iterationsCount; i++) {
+        let sumReal = 0;
+        let sumImag = 0;
+        for (let i = 0; i < roots.length; i += 2) {
+            let rootReal = roots[i + 0];
+            let rootImag = roots[i + 1];
+            let diffReal = realZ - rootReal;
+            let diffImag = imagZ - rootImag;
+            if (diffReal < 0.001 && diffImag < 0.001) {
+                return i;
+            }
+            // 1/(x + yi) = x/(x^2 + y^2) - (y/(x^2 + y^2))i
+            // (a + bi) + 1/(x + yi) = (a + x/(x^2 + y^2)) + (b - y/(x^2 + y^2))i
+            let squareNorm = diffReal * diffReal + diffImag * diffImag;
+            sumReal += diffReal / squareNorm;
+            sumImag += diffImag / -squareNorm;
+        }
+        // 1/(x + yi) = x/(x^2 + y^2) - (y/(x^2 + y^2))i
+        // (a + bi) - 1/(x + yi) = (a - x/(x^2 + y^2)) + (b + y/(x^2 + y^2))i
+        let squareNorm = sumReal * sumReal + sumImag * sumImag;
+        realZ += sumReal / -squareNorm;
+        imagZ += sumImag / squareNorm;
+    }
+
+    // Failing a close-enough match, find and return the root with the nearest distance.
+    let minDistance = Infinity;
+    let closestRootId = 0;
+
+    for (let i = 0; i < roots.length; i += 2) {
+        let rootReal = roots[i + 0];
+        let rootImag = roots[i + 1];
+        let dst = complexAbs(realZ - rootReal, imagZ - rootImag);
+        if (dst < minDistance) {
+            minDistance = dst;
+            closestRootId = i;
+        }
+    }
+    return closestRootId;
+    ```
+
+    Then, in the inner loop, I take advantage of a useful mathematical identity to avoid some
+    calls to `Math.abs` (cheap) as well as an extra floating point comparison (expensive).
+    `a < b and c < d` and `a + c < b + d` are equivalent provided all four variables are
+    non-negative. If I square both sides of each comparison, `a < b` and `c < d`, that condition
+    would be guaranteed, and that leaves the following expression: `a^2 + c^2 < b^2 * d^2`. When
+    I substitute `diffReal` for `a`, `diffImag` for `c`, and `0.001` for `b` and `d`, I get the
+    following expression:
+
+    ```js
+    diffReal * diffReal + diffImag * diffImag < 0.001 * 0.001 + 0.001 * 0.001
+    ```
+
+    The left side just so happens to be the `squareNorm` computed from earlier, and the right
+    side happens to be all constant (it evaluates to `0.000002`). Leveraging this, I can then
+    revise that code to what's now below.
+    */
+
+    let realZ = xp;
+    let imagZ = yp;
+
+    // Perform a Newton's method approximation using `iterationsCount` rounds to find the
+    // nearest root. If it gets close enough to a root, return it.
+    for (let i = 0; i < iterationsCount; i++) {
+        let sumReal = 0;
+        let sumImag = 0;
+        for (let i = 0; i < roots.length; i += 2) {
+            let rootReal = roots[i + 0];
+            let rootImag = roots[i + 1];
+            let diffReal = realZ - rootReal;
+            let diffImag = imagZ - rootImag;
+            // 1/(x + yi) = x/(x^2 + y^2) - (y/(x^2 + y^2))i
+            // (a + bi) + 1/(x + yi) = (a + x/(x^2 + y^2)) + (b - y/(x^2 + y^2))i
+            let squareNorm = diffReal * diffReal + diffImag * diffImag;
+            if (squareNorm < 0.000002) {
+                return i;
+            }
+            sumReal += diffReal / squareNorm;
+            sumImag += diffImag / -squareNorm;
+        }
+        // 1/(x + yi) = x/(x^2 + y^2) - (y/(x^2 + y^2))i
+        // (a + bi) - 1/(x + yi) = (a - x/(x^2 + y^2)) + (b + y/(x^2 + y^2))i
+        let squareNorm = sumReal * sumReal + sumImag * sumImag;
+        realZ += sumReal / -squareNorm;
+        imagZ += sumImag / squareNorm;
+    }
+
+    // Failing a close-enough match, find and return the root with the nearest distance.
+    let minDistance = Infinity;
+    let closestRootId = 0;
+
+    for (let i = 0; i < roots.length; i += 2) {
+        let rootReal = roots[i + 0];
+        let rootImag = roots[i + 1];
+        let dst = complexAbs(realZ - rootReal, imagZ - rootImag);
+        if (dst < minDistance) {
+            minDistance = dst;
+            closestRootId = i;
+        }
+    }
+
+    return closestRootId;
 }
 
 function transformPointToPlotScale(x: number, y: number, plotScale: PlotScale): number[] {
@@ -90,50 +189,18 @@ function fillPixelsJavascript(buffer: SharedArrayBuffer, plotScale: PlotScale, r
         y_display_range: height
     } = plotScale;
     let [w_int, h_int] = [Math.round(width), Math.round(height)];
-
+    
     let flatColors = new Uint8Array(colors.flat());
     let colorPacks = new Uint32Array(flatColors.buffer);
-
-    let complexRoots: Complex32[] = roots.map((pair) => new Complex32(pair[0], pair[1]));
-
-    const filler = (x: number, y: number) => {
-        let minDistance = Number.MAX_SAFE_INTEGER;
-        let closestRootId = 0;
-        let [xp, yp] = transformPointToPlotScale(x, y, plotScale);
-        let z = new Complex32(xp, yp);
-        let colorId = -1;
-        for (let i = 0; i < iterationsCount; i++) {
-            let { idx, z: zNew } = newtonMethodApprox(complexRoots, z);
-            if (idx != -1) {
-                colorId = idx;
-                break;
-            }
-            z = zNew;
-        }
-        if (colorId != -1) {
-            return colorPacks[colorId];
-        }
-        let i = 0;
-        for(const root of complexRoots) {
-            let d = z.clone();
-            d.subtract(root);
-            let dst = d.distance();
-            if (dst < minDistance) {
-                minDistance = dst;
-                closestRootId = i;
-            }
-            i++;
-        }
-        return colorPacks[closestRootId];
-    }
+    let flattenedRoots = Float32Array.from(roots.flat());
+    let u32BufferView = new Uint32Array(buffer, bufferPtr);
 
     let totalSize = w_int * h_int;
     let thisBorder = calculatePartSize(totalSize, partsCount, partOffset, 1);
     let nextBorder = calculatePartSize(totalSize, partsCount, partOffset + 1, 1);
 
-    let u32BufferView = new Uint32Array(buffer, bufferPtr);
-
     for (let i = thisBorder; i < nextBorder; i++) {
-        u32BufferView[i] = filler(i % w_int, i / w_int);
+        let [xp, yp] = transformPointToPlotScale(i % w_int, i / w_int, plotScale);
+        u32BufferView[i] = colorPacks[getRootId(flattenedRoots, iterationsCount, xp, yp)];
     }
 }


### PR DESCRIPTION
This isn't all JS-specific (in fact, most of it isn't), though I used JS for familiarity. I haven't tested or benchmarked this (part of why it's a draft PR), but I created the PR anyways just to help explain.

The long 104-line comment explains most of it, but there's a few key insights into this:

- Every object allocated in JS is allocated on the heap. (Even stacks are commonly heap-allocated.) In performance-critical code, it's common to avoid object allocation entirely. Temporaries that are immediately read from and dropped are typically optimized for and usually are only allocated in the really fast nursery, so the allocation cost here is relatively low (though still non-negligible in hot loops).
- CPUs do better if you can do everything in a row, and memory loads outside L1 cache tend to be significantly costlier than the computation. This is why I flattened the roots: to ensure that the inner loop is dealing with exactly one contiguous array. (I'm using a typed array to match idioms, but normal arrays are more idiomatic.)
- You should prefer `a * sqrt(1 + (a/b)^2)` for computing the two-dimensional Euclidean norm, as it's more numerically stable. (JS has a `Math.hypot(...components)` for this reason.) This happens to require an extra floating point division, but you can reclaim with a floating-point `fma` where available. (This applies across the board, though I see you're already using the WebGL `distance` function, so that's not an issue in the GPU code.)
- You can do a little math and take advantage of both sides being positive to only do one comparison in the inner loop - this may yield a moderate performance boost as you wouldn't need to do the 2 absolute values + 2 floating-point comparisons, but only one single comparison with an already-calculated result. I explain the math in the big comment as well. This holds for all variants, and would also simplify your SIMD condition substantially.

Also, separately, I have a couple larger nits:

- In the TypeScript stuff, using `type Root = [number, number]` and `root: Root[]` would be more idiomatic of a type for your `roots`. (You can also label them as `[x: number, y: number]` for added clarity.) Likewise, `type Color = [number, number, number, number]` + `colors: Color[]` would be clearer and more idiomatic. This would also cause the array's length to get checked for, so you wouldn't be as likely to accidentally forget an entry or add one too many entries.
- You're using 32-bit floating point arithmetic for WebAssembly, while JS uses 64-bit floating point arithmetic natively, so it's not really an apples-to-apples comparison. This should be made clear in the demo.
- In your SIMD calculation, `{i,u}8x16_swizzle(a)` may yield slightly faster code for the [lane shifting](https://github.com/alordash/newton-fractal/blob/main/src/simd_math.rs#L29) than `*_shuffle(a, a)` due to better instruction selection, though that will need benchmarked.
- In your SIMD calculation, I would suggest loading chunks of 4 and doing `let real = f32x4_shuffle::<0, 2, 4, 6>(a, b); let imag = f32x4_shuffle::<0, 2, 4, 6>(a, b);` so you can do it in full batches of 4 using a similar algorithm to the scalar variant. This would require slightly more registers of course and it'd also complicate [finding the matching lane](https://github.com/alordash/newton-fractal/blob/main/src/fractal_calculation.rs#L69-L72) (TL;DR: [`let lane_idx = i32x4_bitmask(f32x4_lt(square_norm, f32x4_splat(0.000002))).trailing_zeros()`](https://en.wikipedia.org/wiki/Find_first_set), lane found if `lane_idx < 4`), but you might derive a full 1.5x speedup from that if not more as you're doing even the expensive operations like `sqrt` fully parallel.